### PR TITLE
exec/local: shore up shutdown

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"github.com/meschbach/plaid/internal/plaid/entry/daemon"
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"
@@ -18,13 +19,20 @@ func main() {
 	rootCmd.AddCommand(&cobra.Command{
 		Use: "run",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, _ := signal.NotifyContext(cmd.Context(), unix.SIGTERM)
+			ctx, _ := signal.NotifyContext(cmd.Context(), unix.SIGTERM, unix.SIGINT)
+			go func() {
+				<-ctx.Done()
+				fmt.Println("[pliadd] Shutting down.")
+			}()
 			cfg := daemon.DefaultConfig(ctx)
 			return daemon.RunWithConfig(cfg)
 		},
 	})
 
 	if err := rootCmd.Execute(); err != nil {
-		os.Exit(-1)
+		_, e := fmt.Fprintf(os.Stderr, "Failed to run with %s\n", err.Error())
+		if e != nil {
+			panic(e)
+		}
 	}
 }

--- a/internal/junk/jtest/context.go
+++ b/internal/junk/jtest/context.go
@@ -1,0 +1,28 @@
+package jtest
+
+import (
+	"context"
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+	"time"
+)
+
+func contextFromEnvTimeout(t *testing.T) (context.Context, func()) {
+	base := context.Background()
+
+	timeoutText, has := os.LookupEnv("TEST_TIMEOUT")
+	if !has {
+		return context.WithCancel(base)
+	} else {
+		timeout, err := time.ParseDuration(timeoutText)
+		require.NoError(t, err, "bad test timeout given: %s", timeoutText)
+		return context.WithTimeout(base, timeout)
+	}
+}
+
+func ContextFromEnv(t *testing.T) context.Context {
+	ctx, done := contextFromEnvTimeout(t)
+	t.Cleanup(done)
+	return ctx
+}

--- a/resources/claims_test.go
+++ b/resources/claims_test.go
@@ -3,22 +3,14 @@ package resources
 import (
 	"context"
 	"github.com/meschbach/plaid/internal/junk"
+	"github.com/meschbach/plaid/internal/junk/jtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	"time"
 )
 
 func TestResourceOwnership(t *testing.T) {
-	done := junk.SetupTestTracing(t)
-	defer func() {
-		shutdown, complete := context.WithTimeout(context.Background(), 1*time.Second)
-		defer complete()
-
-		done(shutdown)
-	}()
-	testCtx, closeTestContext := context.WithCancel(context.Background())
-	t.Cleanup(closeTestContext)
+	testCtx := jtest.ContextFromEnv(t)
 	plaid := WithTestSubsystem(t, testCtx)
 	client := plaid.Controller.Client()
 
@@ -30,10 +22,7 @@ func TestResourceOwnership(t *testing.T) {
 		watcher, err := plaid.Store.Watcher(ctx)
 		require.NoError(t, err)
 		_, err = watcher.OnResource(ctx, existingRef, func(ctx context.Context, changed ResourceChanged) error {
-			switch changed.Operation {
-			default:
-				return nil
-			}
+			return nil
 		})
 		require.NoError(t, err)
 

--- a/resources/optest/system.go
+++ b/resources/optest/system.go
@@ -2,11 +2,10 @@ package optest
 
 import (
 	"context"
+	"github.com/meschbach/plaid/internal/junk/jtest"
 	"github.com/meschbach/plaid/resources"
 	"github.com/stretchr/testify/require"
-	"os"
 	"testing"
-	"time"
 )
 
 type System struct {
@@ -38,20 +37,8 @@ func (s *System) MustCreate(ctx context.Context, ref resources.Meta, spec any) {
 	require.NoError(s.t, s.Legacy.Store.Create(ctx, ref, spec))
 }
 
-func contextFromEnv(t *testing.T) (context.Context, func()) {
-	timeoutText, has := os.LookupEnv("TEST_TIMEOUT")
-	if !has {
-		return context.WithCancel(context.Background())
-	} else {
-		timeout, err := time.ParseDuration(timeoutText)
-		require.NoError(t, err, "bad test timeout given: %s", timeoutText)
-		return context.WithTimeout(context.Background(), timeout)
-	}
-}
-
 func New(t *testing.T) (context.Context, *System) {
-	ctx, done := contextFromEnv(t)
-	t.Cleanup(done)
+	ctx := jtest.ContextFromEnv(t)
 
 	legacy := resources.WithTestSubsystem(t, ctx)
 	systemObserver, err := legacy.Store.Watcher(ctx)


### PR DESCRIPTION
Under some circumstances some process will be leaked.  It appears like there is a concurrency issue while shutting down.  This allows for the supervision tree to be gracefully shutdown in a larger array of conditions by not forcing an OS exit. 

Additionally `local` controller `proc` code has been refactored.  Mostly to be easier to understand, however finer lock control has been put into place as well as warnings on process leakage.