### PR TITLE
reswire/client: now with more locks

### DIFF
--- a/ipc/grpc/reswire/client/wireClientAdapter.go
+++ b/ipc/grpc/reswire/client/wireClientAdapter.go
@@ -120,6 +120,7 @@ func (w *WireClientAdapter) Watcher(ctx context.Context) (Watcher, error) {
 	adapter := &watcherAdapter{
 		wire:     w.wire,
 		stream:   wc,
+		tagsLock: &sync.Mutex{},
 		tags:     make(map[resources.WatchToken]*wireAdapterHandler),
 		ackTable: make(map[uint64]*reswire.WatcherEventOut),
 		ackLock:  &sync.Mutex{},


### PR DESCRIPTION
Provides tag locking within reswire's client implementation.  This prevent concurrent modification to the map for dispatching events.